### PR TITLE
Allow use of HTML in "Clear Favorites Buton" text

### DIFF
--- a/app/Entities/Favorite/ClearFavoritesButton.php
+++ b/app/Entities/Favorite/ClearFavoritesButton.php
@@ -41,7 +41,7 @@ class ClearFavoritesButton
 	public function display()
 	{
 		if ( !$this->user->getsButton() ) return false;
-		if ( !$this->text ) $this->text = $this->settings_repo->clearFavoritesText();
+		if ( !$this->text ) $this->text = html_entity_decode($this->settings_repo->clearFavoritesText());
 		if ( !$this->site_id ) $this->site_id = 1;
 		$out = '<button class="simplefavorites-clear" data-siteid="' . $this->site_id . '">' . $this->text . '</button>';
 		return $out;


### PR DESCRIPTION
HTML entered into the "Clear Favorites Button Text" input on the Favorites settings page was not being displayed properly, but rather exactly as it was entered into the input.