### PR TITLE
Cookie expiration interval

### DIFF
--- a/app/Entities/Favorite/SyncAllFavorites.php
+++ b/app/Entities/Favorite/SyncAllFavorites.php
@@ -49,7 +49,7 @@ class SyncAllFavorites
 	*/
 	public function cookie()
 	{
-		setcookie( 'simplefavorites', json_encode( $this->favorites ), time() + apply_filters( 'simplefavorites_cookie_expiration_interval' , 3600 ), '/' );
+		setcookie( 'simplefavorites', json_encode( $this->favorites ), time() + apply_filters( 'simplefavorites_cookie_expiration_interval', 31556926 ), '/' );
 		return;
 	}
 

--- a/app/Entities/Favorite/SyncAllFavorites.php
+++ b/app/Entities/Favorite/SyncAllFavorites.php
@@ -49,7 +49,7 @@ class SyncAllFavorites
 	*/
 	public function cookie()
 	{
-		setcookie('simplefavorites', json_encode($this->favorites), time()+31556926, '/' );
+		setcookie( 'simplefavorites', json_encode( $this->favorites ), time() + apply_filters( 'simplefavorites_cookie_expiration_interval' , 3600 ), '/' );
 		return;
 	}
 

--- a/app/Entities/Favorite/SyncSingleFavorite.php
+++ b/app/Entities/Favorite/SyncSingleFavorite.php
@@ -47,11 +47,13 @@ class SyncSingleFavorite
 	*/
 	public function cookie()
 	{
+		$cookie_expiration_time = 3600;
+		
 		if ( $this->user->isFavorite($this->post_id, $this->site_id) ){
-			setcookie('simplefavorites', json_encode($this->removeFavorite()), time()+31556926, '/' );
+			setcookie( 'simplefavorites', json_encode( $this->removeFavorite() ), time() + apply_filters( 'simplefavorites_cookie_expiration_interval' , 3600 ), '/' );
 			return;
 		}
-		setcookie('simplefavorites', json_encode($this->addFavorite()), time()+31556926, '/' );
+		setcookie( 'simplefavorites', json_encode( $this->addFavorite() ), time() + apply_filters( 'simplefavorites_cookie_expiration_interval' , 3600 ), '/' );
 		return;
 	}
 

--- a/app/Entities/Favorite/SyncSingleFavorite.php
+++ b/app/Entities/Favorite/SyncSingleFavorite.php
@@ -47,8 +47,6 @@ class SyncSingleFavorite
 	*/
 	public function cookie()
 	{
-		$cookie_expiration_time = 3600;
-		
 		if ( $this->user->isFavorite($this->post_id, $this->site_id) ){
 			setcookie( 'simplefavorites', json_encode( $this->removeFavorite() ), time() + apply_filters( 'simplefavorites_cookie_expiration_interval' , 3600 ), '/' );
 			return;

--- a/app/Entities/Favorite/SyncSingleFavorite.php
+++ b/app/Entities/Favorite/SyncSingleFavorite.php
@@ -48,10 +48,10 @@ class SyncSingleFavorite
 	public function cookie()
 	{
 		if ( $this->user->isFavorite($this->post_id, $this->site_id) ){
-			setcookie( 'simplefavorites', json_encode( $this->removeFavorite() ), time() + apply_filters( 'simplefavorites_cookie_expiration_interval' , 3600 ), '/' );
+			setcookie( 'simplefavorites', json_encode( $this->removeFavorite() ), time() + apply_filters( 'simplefavorites_cookie_expiration_interval', 31556926 ), '/' );
 			return;
 		}
-		setcookie( 'simplefavorites', json_encode( $this->addFavorite() ), time() + apply_filters( 'simplefavorites_cookie_expiration_interval' , 3600 ), '/' );
+		setcookie( 'simplefavorites', json_encode( $this->addFavorite() ), time() + apply_filters( 'simplefavorites_cookie_expiration_interval', 31556926 ), '/' );
 		return;
 	}
 

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,94 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "This file is @generated automatically"
+    ],
+    "hash": "cf4e818e28b9b975c2f8c88cb7019ee5",
+    "content-hash": "bc5933c7bff35982999ee380e6c1027d",
+    "packages": [
+        {
+            "name": "composer/installers",
+            "version": "v1.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/installers.git",
+                "reference": "b3bd071ea114a57212c75aa6a2eef5cfe0cc798f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/installers/zipball/b3bd071ea114a57212c75aa6a2eef5cfe0cc798f",
+                "reference": "b3bd071ea114a57212c75aa6a2eef5cfe0cc798f",
+                "shasum": ""
+            },
+            "replace": {
+                "shama/baton": "*"
+            },
+            "require-dev": {
+                "composer/composer": "1.0.*@dev",
+                "phpunit/phpunit": "3.7.*"
+            },
+            "type": "composer-installer",
+            "extra": {
+                "class": "Composer\\Installers\\Installer",
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Composer\\Installers\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Kyle Robinson Young",
+                    "email": "kyle@dontkry.com",
+                    "homepage": "https://github.com/shama",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A multi-framework Composer library installer",
+            "homepage": "http://composer.github.com/installers/",
+            "keywords": [
+                "TYPO3 CMS",
+                "TYPO3 Flow",
+                "TYPO3 Neos",
+                "agl",
+                "cakephp",
+                "codeigniter",
+                "drupal",
+                "fuelphp",
+                "installer",
+                "joomla",
+                "kohana",
+                "laravel",
+                "li3",
+                "lithium",
+                "mako",
+                "modulework",
+                "phpbb",
+                "ppi",
+                "silverstripe",
+                "symfony",
+                "wordpress",
+                "zend"
+            ],
+            "time": "2013-08-20 04:37:09"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {
+        "php": ">=5.3.2"
+    },
+    "platform-dev": []
+}


### PR DESCRIPTION
Hi Kyle,

As noted in this support request: https://wordpress.org/support/topic/cookie-expire-time-only-set-1-hour-in-the-future, I was looking for a solution for the short cookie interval. 
During this investigation I came up with a filter to allow a theme developer to change the cookie-interval to any desired value. 

Also: the current WordPress SVN repo version uses 3600 seconds as its default value, but your github version uses 1 year in seconds! 

Please have a look at the filter approach in this pull request.

Thanks,
Ruud