### PR TITLE
Fetching favorites posts by user role

### DIFF
--- a/app/API/functions.php
+++ b/app/API/functions.php
@@ -149,14 +149,15 @@ function the_user_favorites_count($user_id = null, $site_id = null, $filters = n
 
 
 /**
-* Get an array of users who have favorited a post
-* @param $post_id int, defaults to current post
-* @param $site_id int, defaults to current blog/site
-* @return array of user objects
-*/
-function get_users_who_favorited_post($post_id = null, $site_id = null)
+ *  Get an array of users who have favorited a post
+*  @param $post_id int, defaults to current post
+*  @param $site_id int, defaults to current blog/site
+ * @param $role string  defaults to empty
+ * @return array of user objects
+ */
+function get_users_who_favorited_post( $post_id = null, $site_id = null, $role = null )
 {
-	$users = new PostFavorites($post_id, $site_id);
+	$users = new PostFavorites( $post_id, $site_id, $role );
 	return $users->getUsers();
 }
 

--- a/app/Entities/Post/PostFavorites.php
+++ b/app/Entities/Post/PostFavorites.php
@@ -21,6 +21,11 @@ class PostFavorites
 	private $site_id;
 
 	/**
+	* User Role
+	*/
+	private $role;
+
+	/**
 	* User Repository
 	* @var SimpleFavorites\Entities\User\UserRepository;
 	*/
@@ -32,11 +37,12 @@ class PostFavorites
 	*/
 	private $favorite_count;
 
-	public function __construct($post_id, $site_id)
+	public function __construct($post_id, $site_id, $role)
 	{
-		$this->post_id = ( $post_id ) ? $post_id : get_the_id();
-		$this->site_id = ( $site_id ) ? $site_id : 1;
-		$this->user_repo = new UserRepository;
+		$this->post_id        = ( $post_id ) ? $post_id : get_the_id();
+		$this->site_id        = ( $site_id ) ? $site_id : 1;
+		$this->role           = ( $role ) ? $role : '';
+		$this->user_repo      = new UserRepository;
 		$this->favorite_count = new FavoriteCount;
 	}
 
@@ -56,13 +62,18 @@ class PostFavorites
 	}
 
 	/**
-	* Get all Users
+	* Get all Users.
+	*
+	* If a role is defined, will fetch users of defined role
 	*/
 	private function getAllUsers()
 	{
-		$user_query = new \WP_User_Query(array(
-			'blog_id' => ( $this->site_id ) ? $this->site_id : 1
-		));
+		$user_query = new \WP_User_Query(
+			array(
+				'blog_id' => ( $this->site_id ) ? $this->site_id : 1,
+				'role'    => $this->role
+			)
+		);
 		$users = $user_query->get_results();
 		return $users;
 	}


### PR DESCRIPTION
This PR allows one to fetch favorites posts by user role, for example:

`get_users_who_favorited_post( 'subscriber' );`
`get_users_who_favorited_post( 'custom-user-role' );`

In this way, I don't need to extend `PostFavorites` class.
