### PR TITLE
Add filter for 'authentication_redirect_url'

### DIFF
--- a/app/Activation/Dependencies.php
+++ b/app/Activation/Dependencies.php
@@ -121,7 +121,7 @@ class Dependencies
 			'user_id' => get_current_user_id()
 		);
 		$redirect_url = $this->settings_repo->redirectAnonymousId();
-		$localized_data['authentication_redirect_url'] = ( $redirect_url ) ? get_the_permalink($redirect_url) : wp_login_url();
+		$localized_data['authentication_redirect_url'] = ( $redirect_url ) ? get_the_permalink($redirect_url) : apply_filters( 'favorites/authentication_redirect_url', wp_login_url() );
 		wp_localize_script(
 			'favorites',
 			'favorites_data',


### PR DESCRIPTION
This PR adds a new filter that can be used to override the default `redirect_url` created by `wp_login_url()`.

This was created from the need to forward the user to a specific URL that doesn't have _known_ page ID in WordPress.