### PR TITLE
Move the `Factory` initialisation after declaration

### DIFF
--- a/assets/js/src/favorites.factory.js
+++ b/assets/js/src/favorites.factory.js
@@ -17,10 +17,6 @@
 function favorites_after_button_submit(favorites, post_id, site_id, status){}
 function favorites_after_initial_load(favorites){}
 
-jQuery(document).ready(function(){
-	new Favorites.Factory;
-});
-
 var Favorites = Favorites || {};
 
 /**
@@ -114,3 +110,7 @@ Favorites.Factory = function()
 
 	return plugin.build();
 }
+
+jQuery(document).ready(function(){
+	new Favorites.Factory;
+});


### PR DESCRIPTION
The document might be ready before the script is executed, so we need to have the `Favorites.Factory` initialisation after the declaration, otherwise there will be an error.