### PR TITLE
Add 2 parameters to [user_favorites] shortcode to filter by taxonomy terms also

### DIFF
--- a/app/API/Shortcodes/UserFavoritesShortcode.php
+++ b/app/API/Shortcodes/UserFavoritesShortcode.php
@@ -32,6 +32,8 @@ class UserFavoritesShortcode
 			'site_id' => '',
 			'include_links' => 'true',
 			'post_types' => '',
+			'taxonomy' => '',
+			'terms' =>	'',
 			'include_buttons' => 'false',
 			'include_thumbnails' => 'false',
 			'thumbnail_size' => 'thumbnail',
@@ -47,7 +49,20 @@ class UserFavoritesShortcode
 	{
 		if ( $this->options['post_types'] == "" ) return;
 		$post_types = explode(',', $this->options['post_types']);
-		$this->filters = ['post_type' => $post_types];
+		$this->filters['post_type'] = $post_types;
+	}
+	
+	/**
+	 * Parse Taxonomy and terms
+	 */
+	private function parseTaxonomyAndTerms()
+	{
+		if ( $this->options['taxonomy'] == ""  || $this->options['terms'] == "" ) return;
+		$this->filters['terms'] = [
+				$this->options['taxonomy'] => [
+						$this->options['terms']
+				]
+		];
 	}
 
 	/**
@@ -58,6 +73,7 @@ class UserFavoritesShortcode
 	{
 		$this->setOptions($options);
 		$this->parsePostTypes();
+		$this->parseTaxonomyAndTerms();
 		
 		if ( $this->options['user_id'] == "" ) $this->options['user_id'] = null;
 		if ( $this->options['site_id'] == "" ) $this->options['site_id'] = null;


### PR DESCRIPTION
Added 2 arguments to the shortcode: 
- taxonomy
- terms 

Simply uses already coded Favorites filters, to filter user favorites by taxonomy terms, as well as by post type 