### PR TITLE
Support "permalink" post value in the FavoriteButton listener

### DIFF
--- a/app/Listeners/FavoriteButton.php
+++ b/app/Listeners/FavoriteButton.php
@@ -17,7 +17,11 @@ class FavoriteButton extends AJAXListenerBase
 	*/
 	private function setFormData()
 	{
-		$this->data['postid'] = intval(sanitize_text_field($_POST['postid']));
+		if (isset($_POST['permalink'])) {
+			$this->data['postid'] = url_to_postid(sanitize_text_field($_POST['permalink']));
+		} else {
+			$this->data['postid'] = intval(sanitize_text_field($_POST['postid']));
+		}
 		$this->data['siteid'] = intval(sanitize_text_field($_POST['siteid']));
 		$this->data['status'] = ( $_POST['status'] == 'active') ? 'active' : 'inactive';
 		$this->data['groupid'] = ( isset($_POST['groupid']) && $_POST['groupid'] !== '' ) ? intval($_POST['groupid']) : 1;


### PR DESCRIPTION
I've got a page where posts are listed with hrefs (permalinks), but I don't have access to the postid's. So I want to be able to provide the permalink to the `favorites_favorite` action instead of the post id.