### PR TITLE
Fixes issue with "Settings" button for Loading Indicator

### DIFF
--- a/app/Views/settings/settings-display.php
+++ b/app/Views/settings/settings-display.php
@@ -194,7 +194,7 @@ $button_type_selected = $this->settings_repo->getButtonType();
 		</div>
 		<div class="post-type-name">
 			<?php _e('Display loading indicator for buttons', 'favorites'); ?> <em>(<?php _e('Helpful for slow sites with cache enabled', 'favorites'); ?>)</em>
-			<button class="button" data-favorites-toggle-post-type-settings <?php if ( !$display ) echo 'style="display:none;"';?>><?php _e('Settings', 'favorites'); ?></button>
+			<button class="button" data-favorites-toggle-post-type-settings <?php if ( ! $this->settings_repo->includeLoadingIndicator() ) echo 'style="display:none;"';?>><?php _e('Settings', 'favorites'); ?></button>
 		</div>
 		<div class="post-type-settings">
 			<div class="row">


### PR DESCRIPTION
On the _Favorites Settings > Display & Post Types_ screen, under the _Favorite Button Loading Indication_ section, the settings button would not be displayed on pageload until the user toggled the checkbox on and off. This PR fixes the issue using the same conditional pattern as used in the _Listing Display_ section below it.