### PR TITLE
Fixed for PHP 8.2

### DIFF
--- a/app/Entities/Favorite/FavoritesArrayFormatter.php
+++ b/app/Entities/Favorite/FavoritesArrayFormatter.php
@@ -62,15 +62,15 @@ class FavoritesArrayFormatter
 	*/
 	private function resetIndexes()
 	{
-		foreach ( $this->formatted_favorites as $site => $site_favorites ){
+		foreach ($this->formatted_favorites as $site => $site_favorites) {
 			// Make older posts compatible with new name
-			if ( !isset($site_favorites['posts']) ) {
+			if (!isset($site_favorites['posts'])) {
 				$site_favorites['posts'] = $site_favorites['site_favorites'];
 				unset($this->formatted_favorites[$site]['site_favorites']);
 			}
-			foreach ( $site_favorites['posts'] as $key => $favorite ){
+			foreach ($site_favorites['posts'] as $key => $favorite) {
 				unset($this->formatted_favorites[$site]['posts'][$key]);
-				$this->formatted_favorites[$site]['posts'][$favorite]['post_id'] = $favorite;
+				$this->formatted_favorites[$site]['posts'][$favorite] = ['post_id' => $favorite];
 			}
 		}
 	}


### PR DESCRIPTION

Fixed the following errors in PHP 8.2

```
PHP Fatal error:  Uncaught Error: Cannot use a scalar value as an array in /var/www/html/wp-content/plugins/favorites/app/Entities/Favorite/FavoritesArrayFormatter.php:73
Stack trace:
#0 /var/www/html/wp-content/plugins/favorites/app/Entities/Favorite/FavoritesArrayFormatter.php(55): Favorites\Entities\Favorite\FavoritesArrayFormatter->resetIndexes()
#1 /var/www/html/wp-content/plugins/favorites/app/Entities/User/UserRepository.php(212): Favorites\Entities\Favorite\FavoritesArrayFormatter->format(Array, NULL, NULL, NULL)
#2 /var/www/html/wp-content/plugins/favorites/app/Listeners/FavoritesArray.php(27): Favorites\Entities\User\UserRepository->formattedFavorites()
#3 /var/www/html/wp-content/plugins/favorites/app/Listeners/FavoritesArray.php(18): Favorites\Listeners\FavoritesArray->setFavorites()
#4 /var/www/html/wp-content/plugins/favorites/app/Events/RegisterPublicEvents.php(62): Favorites\Listeners\FavoritesArray->__construct()
#5 /var/www/html/wp-includes/class-wp-hook.php(324): Favorites\Events\RegisterPublicEvents->favoritesArray('')
#6 /var/www/html/wp-includes/class-wp-hook.php(348): WP_Hook->apply_filters('', Array)
#7 /var/www/html/wp-includes/plugin.php(517): WP_Hook->do_action(Array)
#8 /var/www/html/wp-admin/admin-ajax.php(192): do_action('wp_ajax_favorit...')
#9 {main}
  thrown in /var/www/html/wp-content/plugins/favorites/app/Entities/Favorite/FavoritesArrayFormatter.php on line 73
```