### PR TITLE
wordpress version 6.7.1 :  Deprecated: Optional parameter $site_id declared before required parameter $all_favorites is implicitly treated as a required parameter

### DIFF
--- a/app/Entities/User/UserRepository.php
+++ b/app/Entities/User/UserRepository.php
@@ -141,8 +141,8 @@ class UserRepository
 		$favorites = $this->favoritesWithSiteID($favorites[0]);
 		$favorites = $this->favoritesWithGroups($favorites);
 
-		if ( !is_null($site_id) && is_null($group_id) ) $favorites = Helpers::pluckSiteFavorites($site_id, $favorites);
-		if ( !is_null($group_id) ) $favorites = Helpers::pluckGroupFavorites($group_id, $site_id, $favorites);
+		if ( !is_null($site_id) && is_null($group_id) ) $favorites = Helpers::pluckSiteFavorites($favorites, $site_id);
+		if ( !is_null($group_id) ) $favorites = Helpers::pluckGroupFavorites($group_id, $favorites, $site_id);
 
 		return $favorites;
 	}
@@ -171,8 +171,8 @@ class UserRepository
 		$favorites = $this->favoritesWithSiteID($favorites);
 		$favorites = $this->favoritesWithGroups($favorites);
 		if ( isset($_POST['user_consent_accepted']) && $_POST['user_consent_accepted'] == 'true' ) $favorites[0]['consent_provided'] = time();
-		if ( !is_null($site_id) && is_null($group_id) ) $favorites = Helpers::pluckSiteFavorites($site_id, $favorites);
-		if ( !is_null($group_id) ) $favorites = Helpers::pluckGroupFavorites($group_id, $site_id, $favorites);
+		if ( !is_null($site_id) && is_null($group_id) ) $favorites = Helpers::pluckSiteFavorites($favorites, $site_id);
+		if ( !is_null($group_id) ) $favorites = Helpers::pluckGroupFavorites($group_id, $favorites, $site_id);
 		return $favorites;
 	}
 

--- a/app/Helpers.php
+++ b/app/Helpers.php
@@ -101,11 +101,12 @@ class Helpers
 	/**
 	* Pluck the site favorites from saved meta array
 	* @since 1.1
+	* @param int $group_id
+	* @param array $all_favorites (user meta)
 	* @param int $site_id
-	* @param array $favorites (user meta)
 	* @return array
 	*/
-	public static function pluckGroupFavorites($group_id, $site_id = 1, $all_favorites)
+	public static function pluckGroupFavorites($group_id, $all_favorites,  $site_id = 1)
 	{
 		foreach($all_favorites as $key => $site_favorites){
 			if ( $site_favorites['site_id'] !== $site_id ) continue;

--- a/app/Helpers.php
+++ b/app/Helpers.php
@@ -111,7 +111,7 @@ class Helpers
 		foreach($all_favorites as $key => $site_favorites){
 			if ( $site_favorites['site_id'] !== $site_id ) continue;
 			foreach ( $all_favorites[$key]['groups'] as $group ){
-				if ( $group['group_id'] == $group_id ){
+				if ( isset($$group_id) && $group['group_id'] == $group_id ){
 					return $group['posts'];
 				}
 			}


### PR DESCRIPTION
wordpress version 6.7.1 :  Deprecated: Optional parameter $site_id declared before required parameter $all_favorites is implicitly treated as a required parameter