### PR TITLE
Fix: Function _load_textdomain_just_in_time was called incorrectly

### DIFF
--- a/app/Favorites.php
+++ b/app/Favorites.php
@@ -7,6 +7,8 @@ class Favorites
 {
 	public static function init()
 	{
+		add_action( 'init', [__CLASS__, 'init_translated']);
+
 		// dev/live
 		global $favorites_env;
 		$favorites_env = 'live';
@@ -14,9 +16,11 @@ class Favorites
 		global $favorites_version;
 		$favorites_version = '2.3.4';
 
+		$app = new Favorites\Bootstrap;
+	}
+
+	public static function init_translated() {
 		global $favorites_name;
 		$favorites_name = __('Favorites', 'favorites');
-
-		$app = new Favorites\Bootstrap;
 	}
 }


### PR DESCRIPTION
This pull request includes changes to the `Favorites` class in the `app/Favorites.php` file. The main purpose of these changes is to initialize the translated version of the `Favorites` name according to the WordPress guidelines & **fix** Error/Notice: **Function _load_textdomain_just_in_time was called incorrectly**

![image](https://github.com/user-attachments/assets/b9b28d03-9650-4210-a25c-10515fb847df)

Changes include:

* Added a new action hook to initialize the translated version of the `Favorites` name (`add_action('init', [__CLASS__, 'init_translated'])`).
* Moved the instantiation of the `Favorites\Bootstrap` class to the `init` method from the `init_translated` method to prevent the error when `WP_DEBUG` is `true`.