### PR TITLE
Improved security in App Helpers view() method

### DIFF
--- a/app/Config/Settings.php
+++ b/app/Config/Settings.php
@@ -63,7 +63,7 @@ class Settings
 	public function settingsPage()
 	{
 		$tab = ( isset($_GET['tab']) ) ? sanitize_text_field($_GET['tab']) : 'general';
-		include( Helpers::view('settings/settings') );
+		include( Helpers::view('settings') );
 	}
 
 	/**

--- a/app/Helpers.php
+++ b/app/Helpers.php
@@ -17,9 +17,17 @@ class Helpers
 	/**
 	* Views
 	*/
-	public static function view($file)
+	public static function view($file, $folder = 'settings')
 	{
-		return dirname(__FILE__) . '/Views/' . $file . '.php';
+		// Sanitaze file name.
+		$file = sanitize_file_name($file);
+		$file = preg_replace('/[^a-zA-Z0-9\-_]/', '', $file);
+
+		// Sanitaze folder name.
+		$folder = sanitize_file_name($folder);
+		$folder = preg_replace('/[^a-zA-Z0-9\-_]/', '', $folder);
+
+		return dirname(__FILE__) . '/Views/' . $folder . '/' . $file . '.php';
 	}
 
 	/**

--- a/app/Views/settings/settings.php
+++ b/app/Views/settings/settings.php
@@ -14,7 +14,7 @@
 	</h2>
 
 	<form method="post" enctype="multipart/form-data" action="options.php">
-		<?php include(Favorites\Helpers::view('settings/settings-' . $tab)); ?>
+		<?php include(Favorites\Helpers::view('settings-' . $tab)); ?>
 		<?php submit_button(); ?>
 	</form>
 </div><!-- .wrap -->


### PR DESCRIPTION
Separating the file from the folder when setting the configuration view removes the '/' from the path, allowing us to sanitize the entries.