### PR TITLE
Fix: clear_favorites_button shortcode not using configured text argument

### DIFF
--- a/app/API/Shortcodes/ClearFavoritesShortcode.php
+++ b/app/API/Shortcodes/ClearFavoritesShortcode.php
@@ -33,7 +33,7 @@ class ClearFavoritesShortcode
 	{
 		$this->setOptions($options);
 		$this->options['site_id'] = ( $this->options['site_id'] == "" ) ? null : intval($this->options['site_id']);
-		$this->options['text'] = ( $this->options['text'] == "" ) ? null : sanitize_text_field($this->options['site_id']);
+		$this->options['text'] = ( $this->options['text'] == "" ) ? null : sanitize_text_field($this->options['text']);
 		return get_clear_favorites_button($this->options['site_id'], $this->options['text']);
 	}
 }


### PR DESCRIPTION
The sanitize_text_field() call was incorrectly using site_id instead of text, causing the custom text parameter to be ignored in the shortcode.